### PR TITLE
Potential fix for code scanning alert no. 594: Flask app is run in debug mode

### DIFF
--- a/mock_server/app.py
+++ b/mock_server/app.py
@@ -2648,7 +2648,8 @@ def create_adjustment():
 
 if __name__ == "__main__":
     port = int(os.environ.get("MOCK_SERVER_PORT", "5000"))
-    # Note: This is a test mock server, binding to all interfaces and debug mode are acceptable
+    # Note: This is a test mock server; debug can be enabled explicitly via env var if needed.
+    debug = os.environ.get("MOCK_SERVER_DEBUG", "").lower() in {"1", "true", "yes", "on"}
     app.run(
-        host="0.0.0.0", port=port, debug=True
+        host="0.0.0.0", port=port, debug=debug
     )  # noqa: S104, S201 # NOSONAR python:S104,python:S201


### PR DESCRIPTION
Potential fix for [https://github.com/johanna-II/BillingTest/security/code-scanning/594](https://github.com/johanna-II/BillingTest/security/code-scanning/594)

To fix the problem, remove the unconditional `debug=True` from the `app.run` call and instead derive the debug setting from configuration, defaulting to `False`. This ensures that in any environment where this script is executed as `__main__`, debug mode is off unless explicitly enabled (for example, via an environment variable), which aligns with the recommendation while preserving testability.

Concretely, in `mock_server/app.py`, in the `if __name__ == "__main__":` block around lines 2649–2654, introduce a `debug` variable that reads an environment variable such as `FLASK_DEBUG` or `MOCK_SERVER_DEBUG` and uses it to decide whether to enable debug, defaulting to `False`. Then pass that variable to `app.run`. No new imports are needed because `os` is already imported at the top of the file. The rest of the behavior (host, port) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made mock server debug mode configurable via environment variable, replacing the hard-coded setting for improved flexibility across different deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->