### PR TITLE
Potential fix for code scanning alert no. 554: Clear-text logging of sensitive information

### DIFF
--- a/libs/Contract.py
+++ b/libs/Contract.py
@@ -108,7 +108,7 @@ class ContractManager:
 
         endpoint = f"billing/admin/billing-groups/{self.billing_group_id}/contracts"
 
-        logger.info("Deleting contract from billing group %s", self.billing_group_id)
+        logger.info("Deleting contract from a billing group")
 
         try:
             response = self._client.delete(endpoint, headers=headers)


### PR DESCRIPTION
Potential fix for [https://github.com/johanna-II/BillingTest/security/code-scanning/554](https://github.com/johanna-II/BillingTest/security/code-scanning/554)

In general, to fix clear-text logging of sensitive information, you either remove the sensitive value from the logs entirely, or replace it with a non-sensitive or redacted representation (e.g., partially masked, hashed, or replaced with a fixed label). The aim is to keep logs useful for debugging and audit purposes without exposing raw identifiers or secrets that could be misused if logs are accessed.

For this specific case, the best low-impact fix is to stop logging the raw `billing_group_id` in the `delete_contract` method’s `INFO` log line. We can still log that a contract deletion is being attempted, without including the identifier. This preserves behavior of the method and external API calls while reducing leakage. Concretely, in `libs/Contract.py` around line 111, replace:

```python
logger.info("Deleting contract from billing group %s", self.billing_group_id)
```

with a message that does not include the ID, e.g.:

```python
logger.info("Deleting contract from a billing group")
```

No new imports or helper methods are required; it is a simple change to the log message string. We leave other log statements unchanged per the prompt’s focus, and we do not modify functionality of `delete_contract`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging in contract deletion process. No functional changes to user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->